### PR TITLE
oc-fetch-ssh-keys: globally replacing all occurences of '_'

### DIFF
--- a/skeleton-common/usr/local/sbin/oc-fetch-ssh-keys
+++ b/skeleton-common/usr/local/sbin/oc-fetch-ssh-keys
@@ -35,4 +35,4 @@ EOF
 /usr/local/bin/oc-metadata --cached | grep SSH_PUBLIC_KEYS_.*_KEY | cut -d'=' -f 2- | tr -d \' >> /root/.ssh/authorized_keys
 
 # add Server tags keys
-/usr/local/bin/oc-metadata --cached | grep TAGS_.*=AUTHORIZED_KEY | cut -d'=' -f 3- | sed 's/_/\ /' >> /root/.ssh/authorized_keys
+/usr/local/bin/oc-metadata --cached | grep TAGS_.*=AUTHORIZED_KEY | cut -d'=' -f 3- | sed 's/_/\ /g' >> /root/.ssh/authorized_keys


### PR DESCRIPTION
fix #96