### PR TITLE
Workaround authorized_keys2 not being used by some versions of openss…

### DIFF
--- a/skeleton-common/usr/local/sbin/oc-fetch-ssh-keys
+++ b/skeleton-common/usr/local/sbin/oc-fetch-ssh-keys
@@ -29,6 +29,7 @@ cat << EOF > /root/.ssh/authorized_keys
 #        - $> sed 's/ /_/g' ~./ssh/id_rsa.pub
 #   -- Edit the alternative file: \`~/.ssh/authorized_keys2\` which won't be erased at boot
 #
+#   -- Add the keys to \'~/.ssh/instance_keys\' which will be imported
 EOF
 
 # add Scaleway account keys
@@ -36,3 +37,6 @@ EOF
 
 # add Server tags keys
 /usr/local/bin/oc-metadata --cached | grep TAGS_.*=AUTHORIZED_KEY | cut -d'=' -f 3- | sed 's/_/\ /g' >> /root/.ssh/authorized_keys
+
+# Import custom keys
+cat ~/.ssh/instance_keys >> /root/.ssh/authorized_keys


### PR DESCRIPTION
It seems some versions of openSSH don't use the authorized_keys2 file anymore, I wanted a simple way to load additional keys into the authorized keys file without resorting to tags in the control panel.etc

This seemed to be the simplest way I could think of, I'm not a programmer so I'm not sure if this is the best way to go about it or if there really should be some validation done first, either way it seems to work on my ubuntu 14.04 instance.