### PR TITLE
Add an openrc init script that calls oc-generate-ssh-keys

### DIFF
--- a/skeleton-openrc/etc/init.d/sshd-keys
+++ b/skeleton-openrc/etc/init.d/sshd-keys
@@ -1,0 +1,16 @@
+#!/sbin/runscript
+# Copyright (c) 2015 Scaleway <opensource@scaleway.com>
+# Released under the MIT license.
+
+description="SSHD keys"
+
+depend() {
+    need root
+    before sshd
+}
+
+start() {
+    ebegin "Generating SSH host keys"
+    /usr/local/sbin/oc-generate-ssh-keys
+    eend $?
+}

--- a/skeleton-openrc/etc/init.d/sshd-keys
+++ b/skeleton-openrc/etc/init.d/sshd-keys
@@ -6,7 +6,7 @@ description="SSHD keys"
 
 depend() {
     need root
-    before sshd
+    after sshd
 }
 
 start() {


### PR DESCRIPTION
#36

OpenRC systems were already generating ssh host key, but with this script, we are now sure the userdata will be updated and we also have control over the way the ssh host keys will be created, i.e: if we want more secure ssh keys