### PR TITLE
Call `depmod -a` after syncing kernel modules tree

### DIFF
--- a/skeleton-common/usr/local/sbin/scw-sync-kernel-modules
+++ b/skeleton-common/usr/local/sbin/scw-sync-kernel-modules
@@ -33,3 +33,5 @@ then
     mv $TMP_DIR/${KVERSION} $DIR
   fi
 fi
+
+depmod -a


### PR DESCRIPTION
```console
root@clever-euclid:~# scw-sync-kernel-modules
root@clever-euclid:~# modprobe ip6_tables
modprobe: ERROR: ../libkmod/libkmod.c:578 kmod_search_moddep() could not open moddep file '/lib/modules/4.3.3-docker-1/modules.dep.bin'
root@clever-euclid:~# depmod -a
root@clever-euclid:~# modprobe ip6_tables
root@clever-euclid:~# lsmod
Module                  Size  Used by
ip6_tables             11618  0
```

Fixes https://github.com/scaleway/image-tools/issues/154

Before/After running `depmod -a`

```diff
2a3,5
> 525762    4 -rw-r--r--   1 root     root          164 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.devname
> 525755   44 -rw-r--r--   1 root     root        41072 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.dep.bin
> 525760   88 -rw-r--r--   1 root     root        87736 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.symbols.bin
573a577
> 525180   24 -rw-r--r--   1 root     root        23807 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.dep
574a579,582
> 525761   12 -rw-r--r--   1 root     root         8805 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.builtin.bin
> 525756   20 -rw-r--r--   1 root     root        17502 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.alias
> 525758    4 -rw-r--r--   1 root     root           55 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.softdep
> 525757   28 -rw-r--r--   1 root     root        25263 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.alias.bin
575a584
> 525759   72 -rw-r--r--   1 root     root        70724 Feb  2 13:24 /lib/modules/4.3.3-docker-1/modules.symbols
```