### PR TITLE
Refactor scw-serial.conf to avoid errors when using multiple console …

### DIFF
--- a/skeleton-upstart/etc/init/scw-serial.conf
+++ b/skeleton-upstart/etc/init/scw-serial.conf
@@ -14,11 +14,13 @@ respawn
 
 script
     # getting variables from /proc/cmdline
-    console=$(cat /proc/cmdline | tr " " "\n" | grep ^console= | cut -d= -f2)
-    tty=$(echo $console | cut -d, -f1)
-    attrs=$(echo $console | cut -d, -f2)
-    baud=$(echo $attrs | cut -dn -f1)
+    consoles=$(cat /proc/cmdline | tr " " "\n" | grep ^console= | cut -d= -f2)
+    echo "$consoles" | while read console; do
+        tty=$(echo $console | cut -d, -f1)
+        attrs=$(echo $console | cut -d, -f2)
+        baud=$(echo $attrs | cut -dn -f1)
 
-    # start getty
-    exec /sbin/getty -L ${tty:-ttyS0} ${baud:-9600} vt220
+        # start getty for the first console= entry
+        exec /sbin/getty -L ${tty:-ttyS0} ${baud:-9600} vt220
+    done
 end script


### PR DESCRIPTION
…in /proc/cmdline

Actually we only take the first occurence of `console=` to keep only one `exec` in the script