### PR TITLE
Disable proxy usage when fetching server's data

### DIFF
--- a/skeleton-common/usr/local/bin/scw-metadata
+++ b/skeleton-common/usr/local/bin/scw-metadata
@@ -17,7 +17,7 @@ else
         # Using curl
         CODE=0
         while [ $CODE -ne 200 ]; do
-            RESPONSE=$(curl --silent --write-out "\n%{http_CODE}\n" $METADATA_URL)
+            RESPONSE=$(curl --noproxy '*' --silent --write-out "\n%{http_CODE}\n" $METADATA_URL)
             CODE=$(echo "$RESPONSE" | sed -n '$p')
             BODY=$(echo "$RESPONSE" | sed '$d')
 
@@ -31,7 +31,7 @@ else
     else
         # Using wget
         for i in 1 2 3 4 5; do
-            BODY=$(wget --quiet -O- $METADATA_URL)
+            BODY=$(wget --no-proxy --quiet -O- $METADATA_URL)
 	    echo "$BODY" | grep PRIVATE_IP >/dev/null
             if [ $? -eq 0 ]; then
 		echo "$BODY" > /run/scw-metadata.cache

--- a/skeleton-common/usr/local/bin/scw-metadata-json
+++ b/skeleton-common/usr/local/bin/scw-metadata-json
@@ -7,7 +7,7 @@ export PATH="${PATH:+$PATH:}/usr/bin:/bin"
 CODE=0
 while [ $CODE -ne 200 ]
 do
-    RESPONSE=$(curl --silent --write-out "\n%{http_CODE}\n" http://169.254.42.42/conf?format=json)
+    RESPONSE=$(curl --noproxy '*' --silent --write-out "\n%{http_CODE}\n" http://169.254.42.42/conf?format=json)
     CODE=$(echo "$RESPONSE" | sed -n '$p')
     BODY=$(echo "$RESPONSE" | sed '$d')
     test $CODE -eq 200 && break

--- a/skeleton-common/usr/local/sbin/scw-userdata
+++ b/skeleton-common/usr/local/sbin/scw-userdata
@@ -11,7 +11,7 @@ get() {
     URL=$1
     if type curl >/dev/null 2>/dev/null; then
         # Using curl
-        RESPONSE=$(curl --local-port 1-1024 --silent --write-out "\n%{http_CODE}\n" $URL)
+        RESPONSE=$(curl --local-port 1-1024 --noproxy '*' --silent --write-out "\n%{http_CODE}\n" $URL)
         CODE=$(echo "$RESPONSE" | sed -n '$p')
         BODY=$(echo "$RESPONSE" | sed '$d')
 	echo "$BODY"
@@ -25,7 +25,7 @@ patch() {
     DATA="$2"
     if type curl >/dev/null 2>/dev/null; then
         # Using curl
-        RESPONSE=$(curl --local-port 1-1024 -X PATCH -d "$DATA" -H "Content-Type: text/plain" --silent --write-out "\n%{http_CODE}\n" $URL)
+        RESPONSE=$(curl --local-port 1-1024 --noproxy '*' -X PATCH -d "$DATA" -H "Content-Type: text/plain" --silent --write-out "\n%{http_CODE}\n" $URL)
     else
 	echo "'curl' dependency is missing." >&2
     fi


### PR DESCRIPTION
Proxy usage can seriously interfer with `scw-*` scripts, by getting metadatas of another server.