### PR TITLE
Cleanse shell scripts of bashisms

### DIFF
--- a/skeleton-common/usr/local/bin/scw-check-kernel
+++ b/skeleton-common/usr/local/bin/scw-check-kernel
@@ -1,70 +1,75 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # description "checks the version/config of the kernel"
 # author "Scaleway <opensource@scaleway.com>"
+set -eu
 
 CONFIG_FILE=/etc/scw-kernel-check.conf
 
-function warn_version {
-    if [ ! -z "$EXPECT_MINOR_MIN" ]
-    then
-	echo "Warning: this image expects a Linux kernel >= $EXPECT_MAJOR_MIN.$EXPECT_MINOR_MIN (you are using $KERNEL_VERSION) ; consider using another scaleway bootscript." | tee /dev/stderr /dev/console
-    else
-	echo "Warning: this image expects a Linux kernel >= $EXPECT_MAJOR_MIN.0 (you are using $KERNEL_VERSION), consider using another scaleway bootscript." | tee /dev/stderr /dev/console
-    fi
+warn_expect_kernel() {
+	echo "Warning: this image expects a Linux kernel $*;" \
+		"consider using another scaleway bootscript." \
+		| tee /dev/stderr /dev/console
 }
 
-function warn_config {
-    echo "Warning: this image expects a Linux kernel with $1, consider using another scaleway bootscript." | tee /dev/stderr /dev/console
+warn_version() {
+	warn_expect_kernel \
+		">= $EXPECT_MAJOR_MIN.${EXPECT_MINOR_MIN:-0}" \
+		"(you are using $KERNEL_VERSION)"
 }
 
-if [ -f $CONFIG_FILE ]
-then
-    source $CONFIG_FILE
+warn_config() {
+	warn_expect_kernel "with $1"
+}
 
-    # check if the current kernel version is >= to the expected one
-    KERNEL_VERSION=$(uname -r)
-    MAJOR=$(echo $KERNEL_VERSION | cut -d'.' -f1)
-    MINOR=$(echo $KERNEL_VERSION | cut -d'.' -f2)
-    if [ ! -z "$EXPECT_MAJOR_MIN" ] && [ $MAJOR -lt $EXPECT_MAJOR_MIN ]
-    then
-        warn_version
-        exit 1
-    elif [ ! -z "$EXPECT_MAJOR_MIN" ] && [ $MAJOR -eq $EXPECT_MAJOR_MIN ]
-    then
-        if [ ! -z "$EXPECT_MAJOR_MIN" ] && [ ! -z "$EXPECT_MINOR_MIN" ] && [ $MINOR -lt $EXPECT_MINOR_MIN ]
-        then
-            warn_version
-            exit 1
-        fi
-    fi
+check_version() {
+	[ "${EXPECT_MAJOR_MIN+}" ] || return 0
+	[ "$MAJOR" -gt "$EXPECT_MAJOR_MIN" ] && return 0
+	[ "$MAJOR" -lt "$EXPECT_MAJOR_MIN" ] && return 1
 
-    # check any additional required configs
-    FAILED=0
-    for EXPECT_CONFIG in $(env | grep "EXPECT_CONFIG")
-    do
-	EXPECT_LINE=$(echo "$EXPECT_CONFIG" | sed 's/EXPECT_\(.*\)/\1/')
+	[ "${EXPECT_MINOR_MIN+}" ] || return 0
+	[ "$MINOR" -gt "$EXPECT_MINOR_MIN" ] && return 0
+	[ "$MINOR" -lt "$EXPECT_MINOR_MIN" ] && return 1
 
-	EXPECT_CONF=$(echo $EXPECT_LINE | cut -d'=' -f1)
-	EXPECT_VALUE=$(echo $EXPECT_LINE | cut -d'=' -f2)
+	return 0
+}
 
-	if [ "$EXPECT_VALUE" = "y" ]
-	then
-	    if ! zgrep "$EXPECT_CONF=y" /proc/config.gz &> /dev/null
-	    then
-		warn_config $EXPECT_LINE
-		FAILED=1
-	    fi
-	elif [ "$EXPECT_VALUE" = "n" ]
-	then
-	    if zgrep "$EXPECT_CONF=[ym]" /proc/config.gz &> /dev/null
-	    then
-		warn_config $EXPECT_LINE
-		FAILED=1
-	    fi
+expect_config() {
+	if [ "$EXPECT_VALUE" = y ]; then
+		zcat /proc/config.gz | grep -q "^$EXPECT_CONF=y" || return 1
+	elif [ "$EXPECT_VALUE" = n ]; then
+		zcat /proc/config.gz | grep -q "^$EXPECT_CONF=[ym]" && return 1
 	fi
-    done
-    if [ $FAILED -ne 0 ]
-    then
-	exit 1
-    fi
+	return 0
+}
+
+[ -f "$CONFIG_FILE" ] || exit 0
+. "$CONFIG_FILE"
+
+FAILED=0
+
+# check if the current kernel version is >= to the expected one
+KERNEL_VERSION=$(uname -r)
+# extract number before first dot
+MAJOR=${KERNEL_VERSION%%.*}
+# two-step substitution to extract second number between dots
+MINOR=${KERNEL_VERSION#.*}
+MINOR=${MINOR%%.*}
+
+if ! check_version; then
+	warn_version
+	FAILED=1
 fi
+
+# check any additional required configs
+for EXPECT_CONFIG in $(set | grep '^EXPECT_CONFIG_'); do
+	EXPECT_LINE=${EXPECT_CONFIG#EXPECT_}
+	EXPECT_CONF=${EXPECT_LINE%%=*}
+	eval "EXPECT_VALUE=\${EXPECT_$EXPECT_CONF}"
+
+	if ! expect_config; then
+		warn_config "$EXPECT_LINE"
+		FAILED=1
+	fi
+done
+
+exit "$FAILED"

--- a/skeleton-common/usr/local/sbin/scw-fetch-ssh-keys
+++ b/skeleton-common/usr/local/sbin/scw-fetch-ssh-keys
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # description "fetch SSH keys"
 # author "Scaleway <opensource@scaleway.com>"
 # source "https://github.com/scaleway/image-tools/blob/master/skeleton-common/usr/local/sbin/scw-fetch-ssh-keys"

--- a/skeleton-common/usr/local/sbin/scw-generate-ssh-keys
+++ b/skeleton-common/usr/local/sbin/scw-generate-ssh-keys
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # description "generate SSH keys"
 # author "Scaleway <opensource@scaleway.com>"
 

--- a/skeleton-common/usr/local/sbin/scw-nbd-disconnect-extra
+++ b/skeleton-common/usr/local/sbin/scw-nbd-disconnect-extra
@@ -4,7 +4,7 @@
 
 XNBD_CLIENT=/run/initramfs/usr/sbin/xnbd-client
 
-for device in /dev/nbd[^0]*
+for device in /dev/nbd[!0]*
 do
     ($XNBD_CLIENT -c $device && $XNBD_CLIENT -d $device > /dev/null 2>&1) || true
 done

--- a/skeleton-common/usr/local/sbin/scw-nbd-disconnect-extra
+++ b/skeleton-common/usr/local/sbin/scw-nbd-disconnect-extra
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # description "disconnect extra NBD volumes"
 # author "Scaleway <opensource@scaleway.com>"
 
@@ -6,5 +6,5 @@ XNBD_CLIENT=/run/initramfs/usr/sbin/xnbd-client
 
 for device in /dev/nbd[^0]*
 do
-    ($XNBD_CLIENT -c $device && $XNBD_CLIENT -d $device &> /dev/null) || true
+    ($XNBD_CLIENT -c $device && $XNBD_CLIENT -d $device > /dev/null 2>&1) || true
 done

--- a/skeleton-common/usr/local/sbin/scw-nbd-disconnect-root
+++ b/skeleton-common/usr/local/sbin/scw-nbd-disconnect-root
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 # description "disconnect root NBD volume"
 # author "Scaleway <opensource@scaleway.com>"
 
 XNBD_CLIENT=/run/initramfs/usr/sbin/xnbd-client
-$XNBD_CLIENT --version &> /dev/null
+$XNBD_CLIENT --version > /dev/null 2>&1
 $XNBD_CLIENT -d /dev/nbd0
 echo "b" > /proc/sysrq-trigger

--- a/skeleton-common/usr/local/sbin/scw-swapfile
+++ b/skeleton-common/usr/local/sbin/scw-swapfile
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # description "enables a swapfile"
 # author "Scaleway <opensource@scaleway.com>"
 
@@ -10,40 +10,40 @@ fi
 SWAPFILE_SIZE=4G
 SWAPFILE_PATH=/swapfile
 
-function swapfile_off {
-    if [ -f $SWAPFILE_PATH ]
-    then
-	# this is unfortunate: we have now way of telling NBD that
-	# this file is actually uneeded and we need not to save it in
-	# the block device behind (trying to take advantage of
-	# compression by zero-ing it does not work).
-	#
-	# this means that if we swap, swapped data will be uploaded on
-	# the object storage anyway.
-	swapoff $SWAPFILE_PATH
-	rm -f $SWAPFILE_PATH
-    fi
+swapfile_off() {
+	if [ -f $SWAPFILE_PATH ]
+	then
+		# this is unfortunate: we have now way of telling NBD that
+		# this file is actually uneeded and we need not to save it in
+		# the block device behind (trying to take advantage of
+		# compression by zero-ing it does not work).
+		#
+		# this means that if we swap, swapped data will be uploaded on
+		# the object storage anyway.
+		swapoff $SWAPFILE_PATH
+		rm -f $SWAPFILE_PATH
+	fi
 }
 
-function swapfile_on {
-    # we recreate this file even if it already exists: this way we
-    # handle updates of settings in /etc/scaleway.conf
-    fallocate -l $SWAPFILE_SIZE $SWAPFILE_PATH
-    chmod 600 $SWAPFILE_PATH
-    mkswap $SWAPFILE_PATH
-    swapon $SWAPFILE_PATH
+swapfile_on() {
+	# we recreate this file even if it already exists: this way we
+	# handle updates of settings in /etc/scaleway.conf
+	fallocate -l $SWAPFILE_SIZE $SWAPFILE_PATH
+	chmod 600 $SWAPFILE_PATH
+	mkswap $SWAPFILE_PATH
+	swapon $SWAPFILE_PATH
 }
 
 case $1 in
-    "start")
-	swapfile_on > /dev/null
-	exit $?
-	;;
+	"start")
+		swapfile_on > /dev/null
+		exit $?
+		;;
 
-    "stop")
-	swapfile_off > /dev/null
-	exit $?
-	;;
+	"stop")
+		swapfile_off > /dev/null
+		exit $?
+		;;
 esac
 
 echo >&2 "usage: $0 [start|stop]" ; exit 1

--- a/skeleton-common/usr/local/sbin/scw-sync-connect-extra-volumes
+++ b/skeleton-common/usr/local/sbin/scw-sync-connect-extra-volumes
@@ -1,29 +1,29 @@
-#!/bin/bash
+#!/bin/sh
 # description "sync connect extra NBD volumes"
 # author "Scaleway <opensource@scaleway.com>"
 
 XNBD_CLIENT=/run/initramfs/usr/sbin/xnbd-client
 
 get_value() {
-    /usr/local/bin/scw-metadata --cached "$1"
+	/usr/local/bin/scw-metadata --cached "$1"
 }
 
 sync_connect_extra_volumes() {
-    for nbd_id in $(get_value VOLUMES)
-    do
-	# ignore root nbd device, it is handled differently.
-	test $nbd_id -eq 0 && continue
-
-	export_uri=$(get_value "VOLUMES_${nbd_id}_EXPORT_URI")
-	nbd_host=$(echo $export_uri | sed 's|nbd://\(.*\):.*|\1|')
-	nbd_port=$(echo $export_uri | sed 's|nbd://.*:\(.*\)|\1|')
-
-	device="/dev/nbd${nbd_id}"
-	until ($XNBD_CLIENT -c $device &> /dev/null)
+	for nbd_id in $(get_value VOLUMES)
 	do
-	    ($XNBD_CLIENT $nbd_host $nbd_port -b 4096 $device || sleep 1) &> /dev/null
+		# ignore root nbd device, it is handled differently.
+		test $nbd_id -eq 0 && continue
+
+		export_uri=$(get_value "VOLUMES_${nbd_id}_EXPORT_URI")
+		nbd_host=$(echo $export_uri | sed 's|nbd://\(.*\):.*|\1|')
+		nbd_port=$(echo $export_uri | sed 's|nbd://.*:\(.*\)|\1|')
+
+		device="/dev/nbd${nbd_id}"
+		until $XNBD_CLIENT -c $device > /dev/null 2>&1
+		do
+			($XNBD_CLIENT $nbd_host $nbd_port -b 4096 $device || sleep 1) > /dev/null 2>&1
+		done
 	done
-    done
 }
 
 sync_connect_extra_volumes


### PR DESCRIPTION
went through skeleton-common/usr/local/*bin and eliminated nonportable shell constructs in files marked with a bash shebang so that they should run correctly under a posix shell.

The results are checked with checkbashisms and tested under alpine's busybox ash.

I may have gone a bit overboard in the case of scw-check-kernel which is close to rewritten. Feel free to cherry-pick that out.