### PR TITLE
fixing sync-kernel-headers: adding missing parameter for architecture

### DIFF
--- a/skeleton-common/usr/local/sbin/scw-sync-kernel-headers
+++ b/skeleton-common/usr/local/sbin/scw-sync-kernel-headers
@@ -7,7 +7,7 @@ set -e
 DIR=/usr
 mkdir -p $DIR
 KVERSION=`uname -r`
-
+MACHINE=`uname -m`
 export PATH="${PATH:+$PATH:}/usr/bin:/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin"
 
-wget -q -O - http://mirror.scaleway.com/kernel/${KVERSION}/include.tar | tar -C ${DIR} -xf -
+wget -q -O - http://mirror.scaleway.com/kernel/${MACHINE}/${KVERSION}/include.tar | tar -C ${DIR} -xf -


### PR DESCRIPTION
Looks like the URL scheme from http://mirror.scaleway.com/ has changed, and now includes a machine directory before the kernel version. 
Eg: http://mirror.scaleway.com/kernel/armv7l/3.2.34-30/

This patch adds the required machine argument.