### PR TITLE
authorized_keys permissions 0600

### DIFF
--- a/bases/overlay-common/usr/local/sbin/scw-fetch-ssh-keys
+++ b/bases/overlay-common/usr/local/sbin/scw-fetch-ssh-keys
@@ -46,3 +46,6 @@ if [ -f /root/.ssh/instance_keys ]; then
 EOF
 	(cat /root/.ssh/instance_keys | grep -v "^#" || true) >> /root/.ssh/authorized_keys
 fi
+
+# authorized_keys should only be readable by the owner and no one else
+chmod 0600 /root/.ssh/authorized_keys


### PR DESCRIPTION
SSH authorized_keys file should only be read/writeable by the owner

Set permissions to 0600 after generating the authorized_keys file

Signed-off-by: Hal Martin <hmartin@online.net>