### PR TITLE
Ensure /root always has correct permissions

### DIFF
--- a/bases/overlay-common/usr/local/sbin/scw-fetch-ssh-keys
+++ b/bases/overlay-common/usr/local/sbin/scw-fetch-ssh-keys
@@ -9,6 +9,10 @@ set -e
 mkdir -p /root/.ssh
 chmod 700 /root/.ssh
 
+# ensure /root has the correct permissions
+chown root:root /root
+chmod 700 /root
+
 # `--upgrade` refreshes the metadata cache
 if [ "$1" = "--upgrade" ]; then
 	/usr/local/bin/scw-metadata > /dev/null


### PR DESCRIPTION
sshd will refuse to use authorized_keys if any of the permissions on /root,
/root/.ssh, and /root/.ssh/authorized_keys are incorrect. Therefore, ensure
that each time scw-fetch-ssh-keys is executed, the permissions are re/set to
the correct permissions. This will always allow the user to login using their
scaleway SSH keys

Signed-off-by: Hal Martin <hmartin@online.net>