### PR TITLE
Refactor SSH host key generation

### DIFF
--- a/bases/overlay-common/usr/local/sbin/scw-generate-ssh-keys
+++ b/bases/overlay-common/usr/local/sbin/scw-generate-ssh-keys
@@ -3,12 +3,7 @@
 # author "Scaleway <opensource@scaleway.com>"
 
 # Generate ssh host keys if not present
-if [ ! -f /etc/ssh/ssh_host_rsa_key ]
-then
-    ssh-keygen -t rsa -b 2048 -N '' -f /etc/ssh/ssh_host_rsa_key &
-    ssh-keygen -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key &
-    ssh-keygen -t ecdsa -N '' -f /etc/ssh/ssh_host_ecdsa_key &
-    ssh-keygen -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key || true &
-    wait `jobs -p` || true
+if test -z "$(find /etc/ssh/ -iname 'ssh_host_*_key*')"; then
+    ssh-keygen -A
 fi
-scw-userdata ssh-host-fingerprints "$(for key in /etc/ssh/ssh_host_*_key; do ssh-keygen -lf $key; done)"
+scw-userdata ssh-host-fingerprints "$(find /etc/ssh/ -iname "ssh_host_*_key" -exec ssh-keygen -lf \{\} \;)"

--- a/bases/overlay-systemd/etc/systemd/system-preset/scw.preset
+++ b/bases/overlay-systemd/etc/systemd/system-preset/scw.preset
@@ -1,4 +1,5 @@
 enable scw-fetch-ssh-keys
+enable scw-generate-ssh-keys
 enable scw-sync-kernel-modules
 enable scw-signal-booted
 enable scw-set-hostname

--- a/bases/overlay-systemd/etc/systemd/system/scw-generate-ssh-keys.service
+++ b/bases/overlay-systemd/etc/systemd/system/scw-generate-ssh-keys.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Generate ssh host keys
+ConditionPathExists=|!/etc/ssh/ssh_host_dsa_key
+ConditionPathExists=|!/etc/ssh/ssh_host_dsa_key.pub
+ConditionPathExists=|!/etc/ssh/ssh_host_ecdsa_key
+ConditionPathExists=|!/etc/ssh/ssh_host_ecdsa_key.pub
+ConditionPathExists=|!/etc/ssh/ssh_host_ed25519_key
+ConditionPathExists=|!/etc/ssh/ssh_host_ed25519_key.pub
+ConditionPathExists=|!/etc/ssh/ssh_host_rsa_key
+ConditionPathExists=|!/etc/ssh/ssh_host_rsa_key.pub
+Before=ssh.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/scw-generate-ssh-keys
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
SSH host key generation was previously removed from this repo on the basis that it is a distrib-dependent process, e.g. Arch implements a systemd service that simply does `ssh-keygen -A` if any host key does not exist. However, this proved to be an error, as our scripts did not simply generate the keys but also added them to the server's `user_data`, which can be retrieved through the compute api. This ends up removing a feature and being a pain point for our users.

Add back the systemd service to the systemd overlay, if any distrib-specific way of doing this exists in can be disabled as its features end up being a subset of what we need to do.

Also, refactor the key generation script to be a bit simpler.

This fixes scaleway/scaleway-cli#512.