### PR TITLE
Disambiguate timestamped docker tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ifdef IMAGE_BASE_FLAVORS
 endif
 	docker build $(BUILD_OPTS) -t $(DOCKER_NAMESPACE)/$(IMAGE_NAME):$(TARGET_SCW_ARCH)-$(IMAGE_VERSION) $(foreach ba,$(BUILD_ARGS),--build-arg $(ba)) $$([ -r Dockerfile.$(TARGET_SCW_ARCH) ] && echo "-f Dockerfile.$(TARGET_SCW_ARCH)") $(IMAGE_DIR)
 	echo $(DOCKER_NAMESPACE)/$(IMAGE_NAME):$(TARGET_SCW_ARCH)-$(IMAGE_VERSION) >$(EXPORT_DIR)/docker_tags
-	$(eval IMAGE_VERSION_ALIASES += $(shell date +%Y-%m-%d))
+	$(eval IMAGE_VERSION_ALIASES += $(IMAGE_VERSION)-$(shell date +%Y-%m-%d))
 	$(foreach v,$(IMAGE_VERSION_ALIASES),\
 		docker tag $(DOCKER_NAMESPACE)/$(IMAGE_NAME):$(TARGET_SCW_ARCH)-$(IMAGE_VERSION) $(DOCKER_NAMESPACE)/$(IMAGE_NAME):$(TARGET_SCW_ARCH)-$v;\
 		echo $(DOCKER_NAMESPACE)/$(IMAGE_NAME):$(TARGET_SCW_ARCH)-$v >>$(EXPORT_DIR)/docker_tags;)


### PR DESCRIPTION
An oversight on my part was to tag every built docker image with `scaleway/<image>:<arch>-<year-month-day>` along with the other, explicitly required tags. The problem with this scheme arises when two versions of the same image are built on the same day: the one tagged last will shadow the other.

This changes the scheme to `scaleway/<image>:<arch>-<main-version-name>-<year-month-day>`, which should produce the expected behavior (later builds of a version shadow older builds of the same version).