### PR TITLE
Fix empty /etc/hosts from images

### DIFF
--- a/bases/overlay-systemd/etc/systemd/system/scw-set-hostname.service
+++ b/bases/overlay-systemd/etc/systemd/system/scw-set-hostname.service
@@ -2,7 +2,6 @@
 Description=SCW set hostname from metadata on first boot
 Requires=network-online.target
 After=network.target network-online.target
-ConditionFileNotEmpty=!/etc/hostname
 
 [Service]
 Type=oneshot

--- a/bases/overlay-systemd/usr/local/sbin/scw-set-hostname
+++ b/bases/overlay-systemd/usr/local/sbin/scw-set-hostname
@@ -1,10 +1,16 @@
 #! /bin/bash
 
 old_hostname=$(hostnamectl status | grep 'hostname' | cut -d ":" -f2 | tr -d " ")
-new_hostname=$(scw-metadata --cached HOSTNAME)
+new_hostname=$(scw-metadata HOSTNAME)
+
+if ! [ -s /etc/hosts ]; then
+	cp /etc/hosts.default /etc/hosts
+        sed -i "s/\bserver\b/$new_hostname/g" /etc/hosts
+fi
+
 hostnamectl set-hostname $new_hostname
 if grep -q "$old_hostname" /etc/hosts; then
-    sed -i "/$old_hostname/s/.*/127.0.0.1\t$new_hostname/" /etc/hosts
+    sed -i "/$old_hostname/s/\b$old_hostname\b/$new_hostname/g" /etc/hosts
 else
     echo -e "127.0.0.1\t$new_hostname" >> /etc/hosts
 fi


### PR DESCRIPTION
Create a new command and unit to copy /etc/hosts.default
if the file is missing.

Adapt scw-set-hostname unit to require this one if enabled.