### PR TITLE
systemd: fix error thrown by 'sed' in scw-set-hostname

### DIFF
--- a/bases/overlay-systemd/usr/local/sbin/scw-set-hostname
+++ b/bases/overlay-systemd/usr/local/sbin/scw-set-hostname
@@ -1,16 +1,34 @@
-#! /bin/bash
+#!/bin/bash
 
-old_hostname=$(hostnamectl status | grep 'hostname' | cut -d ":" -f2 | tr -d " ")
-new_hostname=$(scw-metadata HOSTNAME)
+set -euo pipefail
 
-if ! [ -s /etc/hosts ]; then
-	cp /etc/hosts.default /etc/hosts
-        sed -i "s/\bserver\b/$new_hostname/g" /etc/hosts
+: ${old_hostname:="$(hostnamectl --static  | tr -d -c '[:graph:]')"}
+: ${new_hostname:="$(scw-metadata HOSTNAME | tr -d -c '[:graph:]')"}
+readonly -- old_hostname new_hostname
+
+# Before anything risky, try to set a hostname to get a usable environment.
+
+if [[ -z "${new_hostname}" ]]; then
+	exit 2
 fi
 
-hostnamectl set-hostname $new_hostname
-if grep -q "$old_hostname" /etc/hosts; then
-    sed -i "/$old_hostname/s/\b$old_hostname\b/$new_hostname/g" /etc/hosts
+if [[ "${old_hostname}" != "${new_hostname}" ]]; then
+	hostnamectl set-hostname "${new_hostname}"
+fi
+
+# Only then attempt any file modifications, which might fail for reasons unrelated to naming.
+
+if ! [[ -s /etc/hosts ]]; then
+	</etc/hosts.default sed -e "s@server@${new_hostname}@g" >/etc/hosts
+	exit 0
+fi
+
+if [[ ! -z "${old_hostname}" ]] && \
+   [[ "${old_hostname}" != *"/"* ]] && \
+   [[ "${old_hostname}" != "localhost"* ]] && \
+   grep -m 1 -q "${old_hostname}" /etc/hosts;
+then
+	sed -i -e "s@${old_hostname}@${new_hostname}@g" /etc/hosts
 else
-    echo -e "127.0.0.1\t$new_hostname" >> /etc/hosts
+	printf "127.0.0.1\t%s\n" "${new_hostname}" >>/etc/hosts
 fi


### PR DESCRIPTION
`hostnamectl` can return more than one hostname, the pair "transient"
and "static" hostname is not uncommon.

The script then fails because `$old_hostname` is set to two lines (!)
with the first being "n/a". Both get passed to `sed` and result in an
invalid script both ways, because `grep` finds it erroneously due to
its special meaning.

Just assume it's not in /etc/hosts