### PR TITLE
added IPv6 address as a fall back address in motd

### DIFF
--- a/bases/overlay-feature-motd/etc/update-motd.d/50-scw
+++ b/bases/overlay-feature-motd/etc/update-motd.d/50-scw
@@ -20,6 +20,11 @@ processes=`ps aux | wc -l`
 ip=$(scw-metadata --cached PRIVATE_IP)
 public_ip=$(scw-metadata --cached PUBLIC_IP_ADDRESS)
 
+if [ -z public_ip ]; then
+	# Fall back to using the IPv6 address
+	public_ip=$(scw-metadata --cached IPV6_ADDRESS)
+fi
+
 metadata() {
   scw-metadata --cached "$1"
 }


### PR DESCRIPTION
shows the IPv6 address when IPv4 address is unavailable. 

Tested on a IPv6 only server.
```               _
 ___  ___ __ _| | _____      ____ _ _   _
/ __|/ __/ _` | |/ _ \ \ /\ / / _` | | | |
\__ \ (_| (_| | |  __/\ V  V / (_| | |_| |
|___/\___\__,_|_|\___| \_/\_/ \__,_|\__, |
                                    |___/

Welcome on Debian Buster (GNU/Linux 4.19.53-mainline-rev1 x86_64 )

System information as of: Sat 14 Mar 2020 06:08:59 PM UTC

System load:    0.08            Int IP Address: 10.64.166.XXX
Memory usage:   0.0%            Pub IP Address: 2001:bc8:47a8:XXX::1
Usage on /:     85%             Swap usage:     0.0%
Local Users:    2               Processes:      91
Image build:    2019-08-27      System uptime:  84 days
Disk vda:       l_ssd 25G

Documentation:  https://github.com/scaleway/image-debian
Community:      https://github.com/scaleway/image-debian
Image source:   https://github.com/scaleway/image-debian
```
