### PR TITLE
Fix parsing of `free -m` for motd generation

### DIFF
--- a/bases/overlay-feature-motd/etc/update-motd.d/50-scw
+++ b/bases/overlay-feature-motd/etc/update-motd.d/50-scw
@@ -12,8 +12,8 @@ fi
 date=`date`
 load=`cat /proc/loadavg | awk '{print $1}'`
 root_usage=`df -h / | awk '/\// {print $(NF-1)}'`
-memory_usage=`free -m | awk '/Mem:/ { total=$2 } /buffers\/cache/ { used=$3 } END { printf("%3.1f%%", used/total*100)}'`
-swap_usage=`free -m | awk '/Swap/ { printf("%3.1f%%", "exit !$2;$3/$2*100") }'`
+memory_usage=`free -m | awk '/Mem:/ { total=$2; available=$7; printf("%3.1f%%", (1-available/total)*100)}'`
+swap_usage=`free -m | awk '/Swap/ { printf("%3.1f%%", $2?$3/$2*100:0) }'`
 users=`users | wc -w`
 time=`uptime | grep -ohe 'up .*' | sed 's/,/\ hours/g' | awk '{ printf $2" "$3 }'`
 processes=`ps aux | wc -l`


### PR DESCRIPTION
When logging into a Debian 10 instance, one is greeted with some system information including:

```text
Memory usage:  0.0%
Swap usage:    0.0%
```

The meters always display `0.0%`, irrespective of the actual usage. These numbers are generated in /etc/update-motd.d/50-scw by awk scripts that incorrectly parse parse the output of `free -m`.

This pull request fixes those scripts. It has been tested on a Debian 10 Scaleway instance and on an Ubuntu 18.04 desktop (tested the parsing of `free -m`).